### PR TITLE
Updated README PEP 8 order and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ This will be an intensive two weeks. We are providing your researchers 6 areas o
 
 1. [Instructions for installing the Anaconda distribution of Python](https://github.com/OpenRG/WB-India#1-instructions-for-installing-the-anaconda-distribution-of-python)
 2. [Text editor suggestions](https://github.com/OpenRG/WB-India#2-text-editor-suggestions)
-3. [PEP 8, docstring commenting, and module structure](https://github.com/OpenRG/WB-India#3-pep-8-docstring-commenting-and-module-structure)
-4. [Jupyter notebooks](https://github.com/OpenRG/WB-India#4-jupyter-notebooks)
-5. [Python tutorials](https://github.com/OpenRG/WB-India#5-python-tutorials)
-6. [Git and GitHub.com tutorial](https://github.com/OpenRG/WB-India#6-git-and-github-tutorial)
+3. [Jupyter notebooks](https://github.com/OpenRG/WB-India#3-jupyter-notebooks)
+4. [Python tutorials](https://github.com/OpenRG/WB-India#4-python-tutorials)
+5. [Git and GitHub.com tutorial](https://github.com/OpenRG/WB-India#5-git-and-github-tutorial)
+6. [PEP 8, docstring commenting, and module structure](https://github.com/OpenRG/WB-India#6-pep-8-docstring-commenting-and-module-structure)
 7. [References](https://github.com/OpenRG/WB-India#7-references)
 
 
@@ -49,11 +49,10 @@ We recommend that each participant download the Anaconda distribution of Python 
 
 ## 2. Text editor suggestions
 
-In our recommended Python development workflow, you will write Python scripts and modules (`*.py` files) in a text editor. Then you will run those scripts from your terminal. You will want a capable text editor for developing your code. Many capable text editors exist, but we recommend three.
+In our recommended Python development workflow, you will write Python scripts and modules (`*.py` files) in a text editor. Then you will run those scripts from your terminal. You will want a capable text editor for developing your code. Many capable text editors exist, but we recommend two.
 
 1. [Atom](https://atom.io)
 2. [Sublime Text 3](https://www.sublimetext.com)
-3. [Vim](http://www.vim.org)
 
 Atom and Vim are completely free. A trial version of Sublime Text 3 is available for free, but a licensed version is $80 (US dollars). In the following subsections, we give some of the details of each of the above three text editors.
 
@@ -83,7 +82,71 @@ For development with GitHub we recommend:
 [Sublime Text 3](https://www.sublimetext.com) is the most widely used and versatile private software text editor. It has tremendous flexibility, as well as the polish of a piece of professional software. Sublime Text 3 will cost $80 for a license, although you can use a trial version indefinitely without charge while only having to suffer through frequent reminders to buy the full version.
 
 
-## 3. PEP 8, docstring commenting, and module structure
+## 3. Jupyter Notebooks
+
+[Jupyter notebooks](http://jupyter.org/) are files that end with the `*.ipynb` suffix. These notebooks are opened in a browser environment and are an open source web application that combines instructional text with live executable and modifyable code for many different programming platforms (e.g., Python, R, Julia). Jupyter notebooks are an ideal tool for teaching programming as they provide the code for a user to execute and they also provide the context and explanation for the code. We have provided a number of Jupyter notebooks in the [Tutorials](https://github.com/OpenRG/WB-India/tree/master/Tutorials) folder of this repository.
+
+These notebooks used to be Python-specific, and were therefore called iPython notebooks (hence the `*.ipynb` suffix). But Jupyter notebooks now support many programming languages, although the name still pays homage to Python with the vestigal "py" in "Jupyter". The notebooks execute code from the kernel of the specific programming language on your local machine.
+
+Jupyter notebooks capability will be automatically installed with your download of the [Anaconda distribution](https://www.anaconda.com/download/) of Python. If you did not download the Anaconda distribution of Python, you can download Jupyter notebooks separately by following the instructions on the Jupyter [install page](http://jupyter.org/install).
+
+
+### 3.1. Opening a Jupyter notebook
+
+Once Jupyter is installed--whether through Anaconda or through the Jupyter website--you can open a Jupyter notebook by the following steps.
+
+1. Navigate in your terminal to the folder in which the Jupyter notebook files reside. In the case of the Jupyter notebook tutorials in this repository, you would navigate to the `~/WB-India/Tutorials/` directory.
+2. Type `jupyter notebook` at the terminal prompt.
+3. A Jupyter notebook session will open in your browser, showing the available `*.ipynb` files in that directory.
+  *  In some cases, you might receive a prompt in the terminal telling you to paste a url into your browser.
+4. Double click on the Jupyter notebook you would like to open.
+
+It is worth noting that you can also simply navigate to the URL of the Jupyter notebook file in the GitHub repository on the web (e.g., [https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb)). You can read the Jupyter notebook on GitHub.com, but you cannot execute any of the cells. You can only execute the cells in the Jupyter notebook when you follow the steps above and open the file from a Jupyter notebook session in your browser.
+
+
+### 3.2. Using an open Jupyter notebook
+
+Once you have opened a Jupyter notebook, you will find the notebook has two main types of cells: Markdown cells and Code cells. Markdown cells have formatted Jupyter notebook markdown text, and serve primarily to present context for the coding cells. A reference for the markdown options in Jupyter notebooks is found in the [Jupyter markdown documentation page](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Working%20With%20Markdown%20Cells.html).
+
+You can edit a Markdown cell in a Jupyter notebook by double clicking on the cell and then making your changes. Make sure the cell-type box in the middle of the top menu bar is set to `Markdown`. To implement your changes in the Markdown cell, type `Shift-Enter`.
+
+A Code cell will have a `In [ ]:` immediately to the left of the cell for input. The code in that cell can be executed by typing `Shift-Enter`. For a Code cell, the  cell-type box in the middle of the top menu bar says `Code`.
+
+
+### 3.3. Closing a Jupyter notebook
+
+When you are done with a Jupyter notebook, you first save any changes that you want to remain with the notebook. Then you close the browser windows associated with that Jupyter notebook session. You should then close the local server instance that was opened to run the Jupyter notebook in your terminal window. On a Mac or Windows, this is done by going to your terminal window and typing `Cmd-C` or `Ctrl-C` and then selecting `y` for yes and hitting `Enter`.
+
+
+## 4. Python tutorials
+
+For this training, we have included in this repository six basic Python tutorials in the [`Tutorials`](https://github.com/OpenRG/WB-India/tree/master/Tutorials) directory.
+
+1. [PythonReadIn.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb). This Jupyter notebook provides instruction on basic Python I/O, reading data into Python, and saving data to disk.
+2. [PythonNumpyPandas.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonNumpyPandas.ipynb). This Jupyter notebook provides instruction on working with data using `NumPy` as well as Python's powerful data library `pandas`.
+3. [PythonDescribe.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonDescribe.ipynb). This Jupyter notebook provides instruction on describing, slicing, and manipulating data in Python.
+4. [PythonFuncs.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonFuncs.ipynb). This Jupyter notebook provides instruction on working with and writing Python functions.
+5. [PythonVisualize.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonVisualize.ipynb). This Jupyter notebook provides instruction on creating visualizations in Python.
+6. [PythonRootMin.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonRootMin.ipynb). This Jupyter notebook provides instruction on implementing univariate and multivariate root finders and unconstrained and constrained minimizers using functions in the [`scipy.optimize`](https://docs.scipy.org/doc/scipy/reference/optimize.html) sub-library.
+
+To further one's Python programming skills, a number of other great resources exist.
+
+* The [official Python 3 tutorial site](https://docs.python.org/3/tutorial/)
+* [QuantEcon.net](https://lectures.quantecon.org/py/) is a site run by [Thomas Sargent](http://www.tomsargent.com/) (NYU Stern) and [John Stachurski](http://johnstachurski.net/) (Australia National University). QuantEcon has a very large number of high-quality economics focused computational tutorials in Python. The first three sections provide a good introduction to Python programming.
+* [Python computational labs](http://www.acme.byu.edu/2017-2018-materials/) of the Applied and Computational Mathematics Emphasis at Brigham Young University.
+* [Code Academy's Python learning module](https://www.codecademy.com/learn/learn-python)
+
+In addition, a number of excellent textbooks and reference manuals are very helpful and may be available in your local library. Or you may just want to have these in your own library. Lutz (2013) is a giant 1,500-page reference manual that has an expansive collection of materials targeted at beginners. Beazley (2009) is a more concise reference but is targeted at readers with some experience using Python. Despite its focus on a particular set of tools in the Python programming language, McKinney (2018) has a great introductory section that can serve as a good starting tutorial. Further, its focus on Python's data analysis capabilities is truly one of the important features of Python. Rounding out the list is Langtangen (2010). This book's focus on scientists and engineers makes it a unique reference for optimization, wrapping C and Fortran and other scientific computing topics using Python.
+
+
+## 5. Git and GitHub tutorial
+
+We have included a tutorial on using [Git and GitHub.com](https://github.com/OpenRG/WB-India/blob/master/Tutorials/git_tutorial.pdf) in the [Tutorials](https://github.com/OpenRG/WB-India/tree/master/Tutorials) directory of this repository. Git is a powerful version control software that comes natively installed on many machines and is widely used. GitHub.com is the most widely used online platform for hosting open source projects and integrating with Git software. Git has a significant learning curve, but it is essential for large collaborations that involve software development.
+
+A more comprehensive Git resource is [*Pro Git*](https://git-scm.com/book/en/v2), by Chacon and Straub (2014). This book is open access, and is available online at [https://git-scm.com/book/en/v2](https://git-scm.com/book/en/v2). But Evans likes having it in his library in hard copy. This book is the difinitive guide with everything Git, and it has as its primary application the interaction between Git and GitHub. However, the workflow described in the tutorial above was hard to find in this Git book.
+
+
+## 6. PEP 8, docstring commenting, and module structure
 
 Computer code executes some set of commands in an organized way. In every case, there are often many ways to execute a set of instructions--some ways more efficient than others. However, code has at least three functions.
 
@@ -108,71 +171,7 @@ Because of the latter two characteristics, Python code has developed some conven
 
 In the text editors Atom, Sublime Text 3, and Vim, you can install Linter packages that highlight areas of your code that break PEP 8 rules and tell you what the violation is.
 
-There are fewer conventions in docstring structure, but we have developed some of our own that are outlined in the [PythonFuncs.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonFuncs.ipynb) Jupyter notebook. See especially Sections 3 and 4 of the Jupyter notebook.
-
-
-## 4. Jupyter Notebooks
-
-[Jupyter notebooks](http://jupyter.org/) are files that end with the `*.ipynb` suffix. These notebooks are opened in a browser environment and are an open source web application that combines instructional text with live executable and modifyable code for many different programming platforms (e.g., Python, R, Julia). Jupyter notebooks are an ideal tool for teaching programming as they provide the code for a user to execute and they also provide the context and explanation for the code. We have provided a number of Jupyter notebooks in the [Tutorials](https://github.com/OpenRG/WB-India/tree/master/Tutorials) folder of this repository.
-
-These notebooks used to be Python-specific, and were therefore called iPython notebooks (hence the `*.ipynb` suffix). But Jupyter notebooks now support many programming languages, although the name still pays homage to Python with the vestigal "py" in "Jupyter". The notebooks execute code from the kernel of the specific programming language on your local machine.
-
-Jupyter notebooks capability will be automatically installed with your download of the [Anaconda distribution](https://www.anaconda.com/download/) of Python. If you did not download the Anaconda distribution of Python, you can download Jupyter notebooks separately by following the instructions on the Jupyter [install page](http://jupyter.org/install).
-
-
-### 4.1. Opening a Jupyter notebook
-
-Once Jupyter is installed--whether through Anaconda or through the Jupyter website--you can open a Jupyter notebook by the following steps.
-
-1. Navigate in your terminal to the folder in which the Jupyter notebook files reside. In the case of the Jupyter notebook tutorials in this repository, you would navigate to the `~/WB-India/Tutorials/` directory.
-2. Type `jupyter notebook` at the terminal prompt.
-3. A Jupyter notebook session will open in your browser, showing the available `*.ipynb` files in that directory.
-  *  In some cases, you might receive a prompt in the terminal telling you to paste a url into your browser.
-4. Double click on the Jupyter notebook you would like to open.
-
-It is worth noting that you can also simply navigate to the URL of the Jupyter notebook file in the GitHub repository on the web (e.g., [https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb)). You can read the Jupyter notebook on GitHub.com, but you cannot execute any of the cells. You can only execute the cells in the Jupyter notebook when you follow the steps above and open the file from a Jupyter notebook session in your browser.
-
-
-### 4.2. Using an open Jupyter notebook
-
-Once you have opened a Jupyter notebook, you will find the notebook has two main types of cells: Markdown cells and Code cells. Markdown cells have formatted Jupyter notebook markdown text, and serve primarily to present context for the coding cells. A reference for the markdown options in Jupyter notebooks is found in the [Jupyter markdown documentation page](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Working%20With%20Markdown%20Cells.html).
-
-You can edit a Markdown cell in a Jupyter notebook by double clicking on the cell and then making your changes. Make sure the cell-type box in the middle of the top menu bar is set to `Markdown`. To implement your changes in the Markdown cell, type `Shift-Enter`.
-
-A Code cell will have a `In [ ]:` immediately to the left of the cell for input. The code in that cell can be executed by typing `Shift-Enter`. For a Code cell, the  cell-type box in the middle of the top menu bar says `Code`.
-
-
-### 4.3. Closing a Jupyter notebook
-
-When you are done with a Jupyter notebook, you first save any changes that you want to remain with the notebook. Then you close the browser windows associated with that Jupyter notebook session. You should then close the local server instance that was opened to run the Jupyter notebook in your terminal window. On a Mac or Windows, this is done by going to your terminal window and typing `Cmd-C` or `Ctrl-C` and then selecting `y` for yes and hitting `Enter`.
-
-
-## 5. Python tutorials
-
-For this training, we have included in this repository six basic Python tutorials in the [`Tutorials`](https://github.com/OpenRG/WB-India/tree/master/Tutorials) directory.
-
-1. [PythonReadIn.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonReadIn.ipynb). This Jupyter notebook provides instruction on basic Python I/O, reading data into Python, and saving data to disk.
-2. [PythonNumpyPandas.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonNumpyPandas.ipynb). This Jupyter notebook provides instruction on working with data using `NumPy` as well as Python's powerful data library `pandas`.
-3. [PythonDescribe.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonDescribe.ipynb). This Jupyter notebook provides instruction on describing, slicing, and manipulating data in Python.
-4. [PythonFuncs.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonFuncs.ipynb). This Jupyter notebook provides instruction on working with and writing Python functions.
-5. [PythonVisualize.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonVisualize.ipynb). This Jupyter notebook provides instruction on creating visualizations in Python.
-6. [PythonRootMin.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonRootMin.ipynb). This Jupyter notebook provides instruction on implementing univariate and multivariate root finders and unconstrained and constrained minimizers using functions in the [`scipy.optimize`](https://docs.scipy.org/doc/scipy/reference/optimize.html) sub-library.
-
-To further one's Python programming skills, a number of other great resources exist.
-
-* The [official Python 3 tutorial site](https://docs.python.org/3/tutorial/)
-* [QuantEcon.net](https://lectures.quantecon.org/py/) is a site run by [Thomas Sargent](http://www.tomsargent.com/) (NYU Stern) and [John Stachurski](http://johnstachurski.net/) (Australia National University). QuantEcon has a very large number of high-quality economics focused computational tutorials in Python. The first three sections provide a good introduction to Python programming.
-* [Python computational labs](http://www.acme.byu.edu/2017-2018-materials/) of the Applied and Computational Mathematics Emphasis at Brigham Young University.
-* [Code Academy's Python learning module](https://www.codecademy.com/learn/learn-python)
-
-In addition, a number of excellent textbooks and reference manuals are very helpful and may be available in your local library. Or you may just want to have these in your own library. Lutz (2013) is a giant 1,500-page reference manual that has an expansive collection of materials targeted at beginners. Beazley (2009) is a more concise reference but is targeted at readers with some experience using Python. Despite its focus on a particular set of tools in the Python programming language, McKinney (2018) has a great introductory section that can serve as a good starting tutorial. Further, its focus on Python's data analysis capabilities is truly one of the important features of Python. Rounding out the list is Langtangen (2010). This book's focus on scientists and engineers makes it a unique reference for optimization, wrapping C and Fortran and other scientific computing topics using Python.
-
-
-## 6. Git and GitHub tutorial
-
-We have included a tutorial on using [Git and GitHub.com](https://github.com/OpenRG/WB-India/blob/master/Tutorials/git_tutorial.pdf) in the [Tutorials](https://github.com/OpenRG/WB-India/tree/master/Tutorials) directory of this repository. Git is a powerful version control software that comes natively installed on many machines and is widely used. GitHub.com is the most widely used online platform for hosting open source projects and integrating with Git software. Git has a significant learning curve, but it is essential for large collaborations that involve software development.
-
-A more comprehensive Git resource is [*Pro Git*](https://git-scm.com/book/en/v2), by Chacon and Straub (2014). This book is open access, and is available online at [https://git-scm.com/book/en/v2](https://git-scm.com/book/en/v2). But Evans likes having it in his library in hard copy. This book is the difinitive guide with everything Git, and it has as its primary application the interaction between Git and GitHub. However, the workflow described in the tutorial above was hard to find in this Git book.
+There are fewer conventions in docstring structure, but we have developed some of our own that are outlined in the [PythonFuncs.ipynb](https://github.com/OpenRG/WB-India/blob/master/Tutorials/PythonFuncs.ipynb) Jupyter notebook. See especially Sections 3 and 4 of the notebook.
 
 
 ## 7. References


### PR DESCRIPTION
This PR moves the PEP 8 section to be section 6, updates the outline links at the beginning, and gets rid of Vim references at the beginning of the Text Editor section.

We'll need to make sure the outline links in the README.md work after this is merged.