### PR TITLE
TPI fix

### DIFF
--- a/Code/Chap3/TPI_inclass.py
+++ b/Code/Chap3/TPI_inclass.py
@@ -143,7 +143,7 @@ while (dist > tpi_tol) & (tpi_iter < tpi_max_iter):
     bmat[0, :] = bvec1
     for p in range(1, S - 1):
         bguess = np.diag(bmat[:p, -p:])
-        b_args = (rpath[:p + 1], wpath[:p + 1], nvec[-p - 1:], bvec1[-p],
+        b_args = (rpath[:p + 1], wpath[:p + 1], nvec[-p - 1:], bvec1[-p - 1],
                   beta, sigma)
         results = opt.root(euler_sys_tpi, bguess, args=(b_args))
         bvec = results.x


### PR DESCRIPTION
Fix index for `nvec1` used in loop over `p`.   @indira-tpru noticed that the time path was not flat if start with `bvec1 = b_ss`, which identified this indexing error.  Thank for noticing this!
